### PR TITLE
Fix minimum translation computation issue

### DIFF
--- a/app/config.example.yml
+++ b/app/config.example.yml
@@ -20,6 +20,9 @@ crowdin:
     key: 123456789abcdef123456789abcdef12
     # You can set a minimum to only pull full-translated languages (from 0 to 100, default: 0)
     min_translated_progress: 0
+    # Only the folders listed below are used to compute the minimal translations. If you don't want this
+    # feature, use ~ instead, it will compute the minimal translation with all the available folders.
+    folders: ['a_folder', 'b_folder']
     download:
         base_dir: /tmp/nelson-download
         # By default, specific region languages are removed; mapping is done by the 2 first letters.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/finder": "2.7.3",
         "symfony/config": "^2.7",
         "monolog/monolog": "~1.0",
-        "akeneo/crowdin-api": "1.0.0-alpha2",
+        "akeneo/crowdin-api": "1.0.0-alpha7",
         "knplabs/github-api": "1.4.14",
         "symfony/dependency-injection": "^2.7",
         "symfony/translation": "^2.7"

--- a/src/Akeneo/Crowdin/TranslatedProgressSelector.php
+++ b/src/Akeneo/Crowdin/TranslatedProgressSelector.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Crowdin;
 
 use Akeneo\Event\Events;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -25,15 +26,31 @@ class TranslatedProgressSelector
     /** @var int */
     protected $minTranslatedProgress;
 
+    /** @var null|array */
+    protected $folders;
+
+    /** @var array */
+    protected $branches;
+
     /**
-     * @param Client $client
-     * @param int    $minTranslatedProgress
+     * @param Client                   $client
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param int                      $minTranslatedProgress
+     * @param null|array               $folders
+     * @param array                    $branches
      */
-    public function __construct(Client $client, EventDispatcherInterface $eventDispatcher, $minTranslatedProgress = 0)
-    {
+    public function __construct(
+        Client $client,
+        EventDispatcherInterface $eventDispatcher,
+        $minTranslatedProgress = 0,
+        $folders = null,
+        $branches = ['master']
+    ) {
         $this->client                = $client;
         $this->eventDispatcher       = $eventDispatcher;
         $this->minTranslatedProgress = $minTranslatedProgress;
+        $this->folders               = $folders;
+        $this->branches              = $branches;
     }
 
     /**
@@ -43,36 +60,102 @@ class TranslatedProgressSelector
      */
     public function display(OutputInterface $output)
     {
-        foreach ($this->packages() as $code => $progress) {
-            $output->write(sprintf('%s (%s%%)', $code, $progress), true);
+        foreach ($this->branches as $branch) {
+            $output->write(
+                sprintf("Languages exported for %s branch (%d%%):", $branch, $this->minTranslatedProgress),
+                true
+            );
+            $table = new Table($output);
+            $table->setHeaders(['locale', 'percentage']);
+            foreach ($this->packages(true, $branch) as $code => $progress) {
+                $table->addRow([$code, sprintf('%d%%', $progress)]);
+            }
+            $table->render();
         }
     }
 
     /**
      * Return the list of packages to import
      *
+     * @param bool        $exclude If set to true, exclude the packages with a translation level too low
+     * @param string|null $branch  If set, list the package for a specific branch
+     *
      * @return array
      */
-    public function packages()
+    public function packages($exclude = true, $branch = null)
     {
         $this->eventDispatcher->dispatch(Events::PRE_CROWDIN_PACKAGES);
 
-        $response = $this->client->api('status')->execute();
-        $xml = simplexml_load_string($response);
-        $codesToImport = [];
+        $maxApproved = -1;
+        $approvedCounts = [];
+        foreach ($this->getAllCrowdinCodes() as $code) {
+            $approved = $this->getApprovedCount($code, $branch);
+            $approvedCounts[$code] = $approved;
+            $maxApproved = max($maxApproved, $approved);
+        }
 
-        foreach ($xml as $xmlElement) {
-            $translated_progress = (int) $xmlElement->translated_progress;
-            if ($translated_progress >= $this->minTranslatedProgress) {
-                $code = (string) $xmlElement->code;
-                $codesToImport[$code] = $translated_progress;
+        $result = [];
+        $minApprovedCount = $maxApproved * $this->minTranslatedProgress / 100;
+        foreach ($approvedCounts as $code => $approvedCount) {
+            if (!$exclude || $approvedCount > $minApprovedCount) {
+                $result[$code] = $approvedCount / $maxApproved * 100;
             }
         }
 
+        asort($result);
+        $result = array_reverse($result);
+
         $this->eventDispatcher->dispatch(Events::POST_CROWDIN_PACKAGES, new GenericEvent($this, [
-            'count' => count($codesToImport),
+            'count' => count($result)
         ]));
 
-        return $codesToImport;
+        return $result;
+    }
+
+    /**
+     * Returns the count of approved strings for a specific language code.
+     *
+     * @param string      $crowdinCode
+     * @param null|string $branch
+     *
+     * @return int
+     */
+    protected function getApprovedCount($crowdinCode, $branch = null)
+    {
+        $query = $this->client->api('language-status');
+        $query->setLanguage($crowdinCode);
+        $response = $query->execute();
+
+        $xml = simplexml_load_string($response);
+
+        $approved = 0;
+        foreach ($xml->files->item as $mainNode) {
+            if ((null !== $branch) && ('branch' === (string) $mainNode->node_type) && ($branch === (string) $mainNode->name)) {
+                foreach ($mainNode->files->item as $mainDir) {
+                    if (null === $this->folders || in_array((string) $mainDir->name, $this->folders)) {
+                        $approved += (int) $mainDir->approved;
+                    }
+                }
+            }
+        }
+
+        return $approved;
+    }
+
+    /**
+     * Returns all the Crowdin codes of the languages for this project.
+     *
+     * @return string[]
+     */
+    protected function getAllCrowdinCodes()
+    {
+        $response = $this->client->api('status')->execute();
+        $xml = simplexml_load_string($response);
+        $codes = [];
+        foreach ($xml as $xmlElement) {
+            $codes[] = (string) $xmlElement->code;
+        }
+
+        return $codes;
     }
 }

--- a/src/Akeneo/DependencyInjection/Configuration/CrowdinConfiguration.php
+++ b/src/Akeneo/DependencyInjection/Configuration/CrowdinConfiguration.php
@@ -46,6 +46,11 @@ class CrowdinConfiguration implements ConfigurationInterface
                             ->scalarNode('base_dir')->isRequired()->end()
                         ->end()
                     ->end()
+                    ->arrayNode('folders')
+                        ->info('List of the folders used for min translation computation')
+                        ->prototype('scalar')->end()
+                        ->defaultValue([null])
+                    ->end()
                 ->end()
             ->end();
     }

--- a/src/Akeneo/Nelson/PullTranslationsExecutor.php
+++ b/src/Akeneo/Nelson/PullTranslationsExecutor.php
@@ -61,14 +61,15 @@ class PullTranslationsExecutor
      */
     public function execute($branches, array $options)
     {
-        $packages = array_keys($this->status->packages());
         $isMapped = $this->isArrayAssociative($branches);
 
-        if (count($packages) > 0) {
-            foreach ($branches as $githubBranch => $crowdinFolder) {
-                if (!$isMapped) {
-                    $githubBranch = $crowdinFolder;
-                }
+        foreach ($branches as $githubBranch => $crowdinFolder) {
+            if (!$isMapped) {
+                $githubBranch = $crowdinFolder;
+            }
+            $packages = array_keys($this->status->packages(true, $crowdinFolder));
+
+            if (count($packages) > 0) {
                 $this->pullTranslations($githubBranch, $crowdinFolder, $packages, $options);
             }
 
@@ -79,7 +80,7 @@ class PullTranslationsExecutor
     /**
      * @param string $githubBranch
      * @param string $crowdinFolder
-     * @param string $packages
+     * @param array  $packages
      * @param array  $options
      */
     protected function pullTranslations($githubBranch, $crowdinFolder, array $packages, array $options)

--- a/src/Akeneo/Resources/config/crowdin.yml
+++ b/src/Akeneo/Resources/config/crowdin.yml
@@ -57,3 +57,5 @@ services:
             - '@crowdin.client'
             - '@event_dispatcher'
             - %crowdin.min_translated_progress%
+            - %crowdin.folders%
+            - %github.branches%


### PR DESCRIPTION
For recall, we can set a minimal translation progress of each language to only send to Github the best translations. For example, you can send only the languages translated more than 80%.

The previous method used the "status" API of Crowdin, but it renders the global translation progress of all the project.

Now, we compute the progress branch per branch, with an ability to set only specific folders for computation.