### PR TITLE
Fix exported folders

### DIFF
--- a/src/Akeneo/Crowdin/TranslatedProgressSelector.php
+++ b/src/Akeneo/Crowdin/TranslatedProgressSelector.php
@@ -132,7 +132,7 @@ class TranslatedProgressSelector
         foreach ($xml->files->item as $mainNode) {
             if ((null !== $branch) && ('branch' === (string) $mainNode->node_type) && ($branch === (string) $mainNode->name)) {
                 foreach ($mainNode->files->item as $mainDir) {
-                    if (null === $this->folders || in_array((string) $mainDir->name, $this->folders)) {
+                    if (null === $this->folders || [null] === $this->folders || in_array((string) $mainDir->name, $this->folders)) {
                         $approved += (int) $mainDir->approved;
                     }
                 }


### PR DESCRIPTION
When conf does not have `folders` item, the configuration is not read as `null` but as `[null]`. It implies no folder is exported. This PR fixes this.