### PR TITLE
Add 'valid_locale-pattern' configuration key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ bin
 app/console
 app/logs/
 !config/example.yml
+!config/example-*.yml
 config/*

--- a/config/example-community-3x.yml
+++ b/config/example-community-3x.yml
@@ -1,0 +1,54 @@
+github:
+    token: the_github_token
+    fork_owner: nelson-akeneo
+    owner: akeneo
+    repository: pim-community-dev
+    branches: ['3.2']
+crowdin:
+    project: akeneo
+    key: the_crowdin_key
+    min_translated_progress: 80
+    download:
+        base_dir: /tmp/crowdin-download
+        valid_locale_pattern: /^[a-z]{2}_[A-Z]{2}$/
+        locale_map:
+            pt-PT: pt_PT
+            pt-BR: pt_BR
+            ca-ES: ca_ES
+            da-DK: da_DK
+            de-DE: de_DE
+            en-US: en_US
+            en-NZ: en_NZ
+            en-GB: en_GB
+            es-ES: es_ES
+            fi-FI: fi_FI
+            fr-FR: fr_FR
+            hr-HR: hr_HR
+            nl-NL: nl_NL
+            it-IT: it_IT
+            ja-JP: ja_JP
+            ko-KR: ko_KR
+            ru-RU: ru_RU
+            zh-CN: zh_CN
+            sv-SE: sv_SE
+            es-VE: es_VE
+            id-ID: id_ID
+            pl-PL: pl_PL
+            ro-RO: ro_RO
+            tl-TL: tl_TL
+            tr-TR: tr_TR
+            uk_UK: uk_UK
+    folders: ['PimCommunity', 'AkeneoCommunity', 'AkeneoToolCommunity']
+    upload:
+        base_dir: /tmp/crowdin-upload
+nelson:
+    finder_options:
+        in: 'src/'
+        notPath: '/Oro/'
+        path: '/Resources\/translations/'
+        name: '*.en_US.yml'
+    target_rules:
+        '/Resources/translations': ''
+        'src/Pim': 'PimCommunity'
+        'src/Akeneo': 'AkeneoCommunity'
+    pattern_suffix: 'Community'

--- a/config/example.yml
+++ b/config/example.yml
@@ -30,6 +30,8 @@ crowdin:
         locale_map:
             fr_FR: fr
             fr_BE: fr_BE
+        # You can specify a valid locale pattern to check after before renaming the files
+        valid_locale_pattern: /^[a-z]{2}_[A-Z]{2}$/
     upload:
         base_dir: /tmp/nelson-upload
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,10 @@ services:
         user: 'docker'
         volumes:
             - './:/srv/nelson'
+            - '${SSH_AUTH_SOCK}:/ssh-agent:ro'
         working_dir: '/srv/nelson'
         environment:
             PHP_IDE_CONFIG: 'serverName=nelson-cli'
             PHP_XDEBUG_ENABLED: "${PHP_XDEBUG_ENABLED:-0}"
             XDEBUG_CONFIG: 'remote_host=172.17.0.1'
+            SSH_AUTH_SOCK: '/ssh-agent'

--- a/src/Akeneo/DependencyInjection/Configuration/CrowdinConfiguration.php
+++ b/src/Akeneo/DependencyInjection/Configuration/CrowdinConfiguration.php
@@ -31,6 +31,7 @@ class CrowdinConfiguration implements ConfigurationInterface
                         ->isRequired()
                         ->children()
                             ->scalarNode('base_dir')->isRequired()->end()
+                            ->scalarNode('valid_locale_pattern')->end()
                             ->arrayNode('locale_map')
                                 ->defaultValue([])
                                 ->useAttributeAsKey('name')

--- a/src/Akeneo/Git/ProjectCloner.php
+++ b/src/Akeneo/Git/ProjectCloner.php
@@ -223,11 +223,11 @@ class ProjectCloner
         ));
 
         // Push latest updates
-        $this->executor->execute(sprintf(
-            'cd %s && git push origin %s',
-            $projectDir,
-            $baseBranch
-        ));
+//        $this->executor->execute(sprintf(
+//            'cd %s && git push origin %s',
+//            $projectDir,
+//            $baseBranch
+//        ));
 
         $this->eventDispatcher->dispatch(Events::POST_GITHUB_UPDATE);
     }

--- a/src/Akeneo/Git/ProjectCloner.php
+++ b/src/Akeneo/Git/ProjectCloner.php
@@ -223,11 +223,11 @@ class ProjectCloner
         ));
 
         // Push latest updates
-//        $this->executor->execute(sprintf(
-//            'cd %s && git push origin %s',
-//            $projectDir,
-//            $baseBranch
-//        ));
+        $this->executor->execute(sprintf(
+            'cd %s && git push origin %s',
+            $projectDir,
+            $baseBranch
+        ));
 
         $this->eventDispatcher->dispatch(Events::POST_GITHUB_UPDATE);
     }

--- a/src/Akeneo/Nelson/PullTranslationsExecutor.php
+++ b/src/Akeneo/Nelson/PullTranslationsExecutor.php
@@ -123,7 +123,12 @@ class PullTranslationsExecutor
         $projectDir = $this->cloner->cloneProject($updateDir, $githubBranch);
         $this->downloader->download($packages, $options['base_dir'], $crowdinFolder);
         $this->extractor->extract($packages, $options['base_dir'], $cleanerDir);
-        $this->translationsCleaner->cleanFiles($options['locale_map'], $cleanerDir, $projectDir);
+        $this->translationsCleaner->cleanFiles(
+            $options['locale_map'],
+            $cleanerDir,
+            $projectDir,
+            $options['valid_locale_pattern'] ?? '/^.+$/'
+        );
         $this->translationsCleaner->moveFiles($cleanerDir, $projectDir);
 
         if ($this->diffChecker->haveDiff($projectDir)) {


### PR DESCRIPTION
When cleaning translation files, Nelson compare the Crowdin file with a `locale_map` array.

If the locale is not in this array, Nelson will then transform the locale name to extract a '_simple locale_' which can be on only two letters. The two letters is not acceptable anymore for PIM >= 3.2, so I added a configuration key with a regex pattern to check the resulting simple locale. If the configuration key is not set, it is defaulting to `/^.+$/`, ie basically anything with at least one character.

This way, Nelson stays compatible with older version and we will have more freedom to validate the locale pattern.

Any file not in the locale map or complying to the pattern will not be renamed and not be pushed to the PIM. We will have to add it to the locale map if we want to integrate it.