### PR TITLE
Add trim on diff checker for shared catalogs

### DIFF
--- a/src/Akeneo/Git/DiffChecker.php
+++ b/src/Akeneo/Git/DiffChecker.php
@@ -37,8 +37,8 @@ class DiffChecker
         $this->eventDispatcher->dispatch(Events::PRE_GITHUB_CHECK_DIFF);
 
         $commands = [
-            sprintf('cd %s && git diff|wc -l', $projectDir),
-            sprintf('cd %s && git ls-files --others --exclude-standard|wc -l', $projectDir),
+            sprintf('cd %s && git diff|wc -l|awk \'{$1=$1};1\'', $projectDir),
+            sprintf('cd %s && git ls-files --others --exclude-standard|wc -l|awk \'{$1=$1};1\'', $projectDir),
         ];
         $diff = 0;
         foreach ($commands as $command) {


### PR DESCRIPTION
We try to implement Crowdin with Shared Catalogs. The push is working correctly, but on the pull we get the following error : 
```
PHP Notice:  Undefined index: diff in /Users/maureen/Akeneo/nelson/src/Akeneo/Git/DiffChecker.php on line 50
```
In the diff checker, we get a string that not match with the regex.
```
"      88
"
```
By trim this string, we get the good diff checker and nelson-akeneo creates a PR. 