### PR TITLE
Fix slack notification when nelson synchronisation does not work

### DIFF
--- a/slack_wrapper.cfg
+++ b/slack_wrapper.cfg
@@ -1,2 +1,1 @@
-SLACK_URL="https://hooks.slack.com/services/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"
 SLACK_CHANNEL="#product-dev"

--- a/slack_wrapper.sh
+++ b/slack_wrapper.sh
@@ -9,11 +9,9 @@ echo "SLACK_CHANNEL=$SLACK_CHANNEL"
 
 send_slack ()
 {
-  curl -X POST --data-urlencode 'payload={"channel": "'"$SLACK_CHANNEL"'", "username": "Nelson", "text": "'"$1"'\n`'"$CMD"'`", "icon_emoji": ":nelson:"}' $SLACK_URL
+  curl -X POST --data-urlencode 'payload={"channel": "'"$SLACK_CHANNEL"'", "username": "Nelson", "text": "'"$1"'\n`'"$CMD"'`", "icon_emoji": ":nelson:"}' $SLACK_URL --insecure
 }
 
-if $CMD; then
-  send_slack "Command executed with success!"
-else
-  send_slack "An error occured during command..."
+if ! "$CMD"; then
+  send_slack "An error occured during synchronization..."
 fi


### PR DESCRIPTION
The synchronisation of nelson does not work since 23 mars 2023 due to https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/. The fingerprint on the server have been changed but the real problem is that we didn't have alert error when it's occurred

In this PR: 
- I updated the hook url used by nelson because the old one have been rotated
- I removed the slack message when nelson synchronization is ok in order to avoid having spam 